### PR TITLE
Add basic Zoho CRM API utilities

### DIFF
--- a/Scripts/Apis.js
+++ b/Scripts/Apis.js
@@ -20,3 +20,11 @@ oServices_CS.Hdi_Cotizacion = { Metodo: "POST", Pagina: "https://apis-alfa.click
 oServices_CS.Mapfre_Cotizacion = { Metodo: "POST", Pagina: "https://apis-alfa.clickseguros.lat/Mapfre/api/Mapfre/Cotizacion" };
 oServices_CS.Momento_Cotizacion = { Metodo: "POST", Pagina: "https://apis-alfa.clickseguros.lat/Momento/api/Momento/Cotizacion" };
 oServices_CS.Zurich_Cotizacion = { Metodo: "POST", Pagina: "https://apis-alfa.clickseguros.lat/Zurich/api/Zurich/Cotizacion" };
+
+var sZohoAccounts = 'https://accounts.zoho.com';
+var sZohoApi = 'https://www.zohoapis.com';
+var oServices_Zoho = {};
+oServices_Zoho.Refresh = sZohoAccounts + '/oauth/v2/token';
+oServices_Zoho.Vehiculos = sZohoApi + '/crm/v2/Vehiculos';
+oServices_Zoho.Vehiculo = function (id) { return sZohoApi + '/crm/v2/Vehiculos/' + id; };
+oServices_Zoho.Attach = function (id) { return oServices_Zoho.Vehiculo(id) + '/Attachments'; };

--- a/Scripts/Carga.js
+++ b/Scripts/Carga.js
@@ -5,6 +5,7 @@ var sCore = "Scripts/Core.js?n=" + iRandom;
 var sApis = "Scripts/Apis.js?n=" + iRandom;
 var sVariables = "Scripts/Variables.js?n=" + iRandom;
 var sGeneral = "Scripts/Generales.js?n=" + iRandom;
+var sZoho = "Scripts/Zoho.js?n=" + iRandom;
 //Estilos
 var sEstilo1 = "Estilos/Variables.css?n=" + iRandom;
 var sEstilo2 = "Estilos/Fuentes.css?n=" + iRandom;
@@ -31,12 +32,14 @@ script2.src = sCore;
 script3.src = sApis;
 script4.src = sVariables;
 script5.src = sGeneral;
+script6.src = sZoho;
 
 document.head.appendChild(script1);
 document.head.appendChild(script2);
 document.head.appendChild(script3);
 document.head.appendChild(script4);
 document.head.appendChild(script5);
+document.head.appendChild(script6);
 
 css1.setAttribute("href", sEstilo1);
 css1.setAttribute("rel", "stylesheet");

--- a/Scripts/Generales.js
+++ b/Scripts/Generales.js
@@ -467,3 +467,17 @@ function Pinta_Paso6(sRespuesta) {
     document.getElementById("lblCob2").innerHTML = oDatos_Grl.Paso3.oCotizacion.coberturas[1].descripcion;
     document.getElementById("lblCob3").innerHTML = oDatos_Grl.Paso3.oCotizacion.coberturas[2].descripcion;
 };
+
+function GeneraLigaCotizador() {
+    var base = "https://cotizar.asegurateya.com/";
+    var params = [];
+    params.push("email=" + encodeURIComponent(oDatos_Grl.Paso2.Correo));
+    params.push("telefono=" + encodeURIComponent(oDatos_Grl.Paso1.Celular));
+    params.push("year=" + oDatos_Grl.Paso1.Modelo);
+    params.push("make=" + encodeURIComponent(oDatos_Grl.Paso1.Marca));
+    params.push("version=" + encodeURIComponent(oDatos_Grl.Paso1.Version));
+    params.push("transmission=" + encodeURIComponent(oDatos_Grl.Paso1.Transmision));
+    params.push("description=" + encodeURIComponent(oDatos_Grl.Paso1.Descripcion));
+    params.push("clave=" + encodeURIComponent(oDatos_Grl.Paso1.ClaveClick));
+    return base + "?" + params.join("&");
+}

--- a/Scripts/Variables.js
+++ b/Scripts/Variables.js
@@ -91,3 +91,51 @@ var oDatos_Cotizacion = {
 
 var oCotizaciones = {};
 var aseguradorasSeleccionadas = [];
+
+var oZohoVehiculo = {
+    Numero_Motor: null,
+    Tipo_de_Venta: "Venta Nueva",
+    Transmision: null,
+    Numero: null,
+    Email: "",
+    Aseguradora: null,
+    Codigo_Postal: 8100,
+    Paso: "1",
+    Prima_Total: 9800,
+    UTM_Term: null,
+    Impuesto: 0,
+    Name: "",
+    Version: null,
+    Apellido: null,
+    Serie: null,
+    Tipo_Vehiculo: "Autos",
+    Anio: "2024",
+    Fecha_Nacimiento: null,
+    UTM_Content: null,
+    Modelo: null,
+    UTM_Medium: null,
+    CotizacionDescargada: null,
+    Colonia: null,
+    UTM_Campaign: null,
+    Cilindrada: null,
+    Estado: null,
+    JsonComparador: null,
+    Genero: "Masculino",
+    Prima_Neta: 0,
+    Derecho: 0,
+    Lista_de_seleccion_1: "Contactar",
+    JsonCotizacion: null,
+    Forma_de_Pago: null,
+    Municipio: null,
+    Documento_Identificacion: null,
+    Segmento: "Baja",
+    Marca: "Bajaj",
+    Cobertura: null,
+    Calle: null,
+    Placa: "placa",
+    UTM_Source: null
+};
+
+var oZohoUpdate = {
+    Lista_de_seleccion_1: "Cotizado"
+};

--- a/Scripts/Zoho.js
+++ b/Scripts/Zoho.js
@@ -1,0 +1,50 @@
+var oZohoCred = {
+    client_id: "",
+    client_secret: "",
+    refresh_token: ""
+};
+
+function ZohoRefreshToken() {
+    var oAjax = new XMLHttpRequest();
+    var sParams = "refresh_token=" + oZohoCred.refresh_token +
+        "&client_id=" + oZohoCred.client_id +
+        "&client_secret=" + oZohoCred.client_secret +
+        "&grant_type=refresh_token";
+    oAjax.open("POST", oServices_Zoho.Refresh, false);
+    oAjax.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    oAjax.send(sParams);
+    var oResp = JSON.parse(oAjax.responseText);
+    return oResp.access_token;
+}
+
+function ZohoCrearVehiculo(oRegistro) {
+    var sToken = ZohoRefreshToken();
+    var oAjax = new XMLHttpRequest();
+    oAjax.open("POST", oServices_Zoho.Vehiculos, false);
+    oAjax.setRequestHeader("Content-Type", "application/json");
+    oAjax.setRequestHeader("Authorization", "Zoho-oauthtoken " + sToken);
+    oAjax.send(JSON.stringify({ data: [oRegistro] }));
+    return JSON.parse(oAjax.responseText);
+}
+
+function ZohoActualizaVehiculo(id, oRegistro) {
+    var sToken = ZohoRefreshToken();
+    var oAjax = new XMLHttpRequest();
+    oAjax.open("PUT", oServices_Zoho.Vehiculo(id), false);
+    oAjax.setRequestHeader("Content-Type", "application/json");
+    oAjax.setRequestHeader("Authorization", "Zoho-oauthtoken " + sToken);
+    oAjax.send(JSON.stringify({ data: [oRegistro] }));
+    return JSON.parse(oAjax.responseText);
+}
+
+function ZohoSubeArchivo(id, oFile) {
+    var sToken = ZohoRefreshToken();
+    var oAjax = new XMLHttpRequest();
+    oAjax.open("POST", oServices_Zoho.Attach(id), false);
+    oAjax.setRequestHeader("Authorization", "Zoho-oauthtoken " + sToken);
+    var oForm = new FormData();
+    oForm.append("file", oFile);
+    oAjax.send(oForm);
+    return JSON.parse(oAjax.responseText);
+}
+


### PR DESCRIPTION
## Summary
- define Zoho endpoints and simple request helpers
- add vehicle data templates and dynamic link generator
- load new Zoho script during page start

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bdb95f048331b2c65c88aa2e093a